### PR TITLE
Fix reading the  Dynamic Symbol table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,10 @@ impl<'a> ElfFile<'a> {
         read_str(&self.get_str_table()[(index as usize)..])
     }
 
+    pub fn get_dyn_string(&self, index: u32) -> &'a str {
+        unimplemented!()
+    }
+
     // This is really, stupidly slow. Not sure how to fix that, perhaps keeping
     // a HashTable mapping names to section header indices?
     pub fn find_section_by_name(&self, name: &str) -> Option<SectionHeader<'a>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,8 @@ impl<'a> ElfFile<'a> {
     }
 
     pub fn get_dyn_string(&self, index: u32) -> &'a str {
-        unimplemented!()
+        let header = self.find_section_by_name(".dynstr").unwrap();
+        read_str(&header.raw_data(self)[(index as usize)..])
     }
 
     // This is really, stupidly slow. Not sure how to fix that, perhaps keeping

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -112,8 +112,11 @@ impl<'a> SectionHeader<'a> {
             ShType::ProcessorSpecific(_) | ShType::User(_) => {
                 SectionData::Undefined(self.raw_data(elf_file))
             }
-            ShType::SymTab | ShType::DynSym => {
+            ShType::SymTab => {
                 array_data!(SymbolTable32, SymbolTable64)
+            }
+            ShType::DynSym => {
+                array_data!(DynSymbolTable32, DynSymbolTable64)
             }
             ShType::StrTab => SectionData::StrArray(self.raw_data(elf_file)),
             ShType::InitArray | ShType::FiniArray | ShType::PreInitArray => {
@@ -282,6 +285,8 @@ pub enum SectionData<'a> {
     FnArray64(&'a [u64]),
     SymbolTable32(&'a [symbol_table::Entry32]),
     SymbolTable64(&'a [symbol_table::Entry64]),
+    DynSymbolTable32(&'a [symbol_table::DynEntry32]),
+    DynSymbolTable64(&'a [symbol_table::DynEntry64]),
     SymTabShIndex(&'a [u32]),
     // Note32 uses 4-byte words, which I'm not sure how to manage.
     // The pointer is to the start of the name field in the note.


### PR DESCRIPTION
Dynamic symbol table entries have their names stored in the `.dynstr` section instead of the `.shstrtab` section. This PR adds a distinction at the type level between dynamic symbols and regular symbols, so that calling `get_name()` will read from the right string table.

Unfortunately, there does not seem to be a good way to find the `.dynstr` section like the `shstrndx` field that exists for the normal string table. Unless I'm missing something, there seem to be two ways: find the section by name, or find the section by byte offset from the `DT_STRTAB` entry in the dynamic section. This PR currently implements the former.

Depends on #11
Conflicts with #13, will rebase if you merge that.
