### PR TITLE
Extend range on Dynamic Tag type

### DIFF
--- a/src/dynamic.rs
+++ b/src/dynamic.rs
@@ -117,7 +117,7 @@ macro_rules! impls {
                     32 => Tag::PreInitArray,
                     33 => Tag::PreInitArraySize,
                     34 => Tag::SymTabShIndex,
-                    t if t >= 0x6000000D && t <= 0x6ffff000 => Tag::OsSpecific(t),
+                    t if t >= 0x6000000D && t <= 0x6fffffff => Tag::OsSpecific(t),
                     t if t >= 0x70000000 && t <= 0x7fffffff => Tag::ProcessorSpecific(t),
                     _ => panic!("Invalid value for tag"),
                 }


### PR DESCRIPTION
The Linux Standard Base defines [additional DT values in the range 0x6ffffd00...0x6fffffff](http://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/libc-ddefs.html#AEN7362) in violation of the ELF specification (actually, I don't know what the authoritative source of the ELF specification is, so this could be totally legit):

|  |  |  |
| --- | --- | --- |
| DT_ADDRRNGHI | DT_ADDRRNGLO | DT_AUDIT |
| DT_CHECKSUM | DT_CONFIG | DT_DEPAUDIT |
| DT_FEATURE_1 | DT_FLAGS_1 | DT_GNU_CONFLICT |
| DT_GNU_CONFLICTSZ | DT_GNU_HASH | DT_GNU_LIBLIST |
| DT_GNU_LIBLISTSZ | DT_GNU_PRELINKED | DT_MOVEENT |
| DT_MOVESZ | DT_MOVETAB | DT_PLTPAD |
| DT_PLTPADSZ | DT_POSFLAG_1 | DT_RELACOUNT |
| DT_RELCOUNT | DT_SYMINENT | DT_SYMINFO |
| DT_SYMINSZ | DT_TLSDESC_GOT | DT_TLSDESC_PLT |
| DT_VALRNGHI | DT_VALRNGLO | DT_VERDEF |
| DT_VERDEFNUM | DT_VERNEED | DT_VERNEEDNUM |
| DT_VERSYM |  |  |

This PR lets xmas-elf work with these by extending the OS-specific range to encompass these values as well.
