### PR TITLE
Add PartialEq and Eq to enums with ...Specific variants

### DIFF
--- a/src/dynamic.rs
+++ b/src/dynamic.rs
@@ -12,7 +12,7 @@ unsafe impl<P> Pod for Dynamic<P> {}
 #[derive(Copy, Clone)]
 pub struct Tag_<P>(P);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Tag<P> {
     Null,
     Needed,

--- a/src/header.rs
+++ b/src/header.rs
@@ -247,7 +247,7 @@ impl fmt::Debug for Type_ {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Type {
     None,
     Relocatable,

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -355,7 +355,7 @@ pub struct CompressionHeader32 {
 #[derive(Copy, Clone)]
 pub struct CompressionType_(u32);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CompressionType {
     Zlib,
     OsSpecific(u32),

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -160,7 +160,7 @@ impl Visibility_ {
 #[derive(Copy, Clone, Debug)]
 pub struct Binding_(u8);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Binding {
     Local,
     Global,
@@ -186,7 +186,7 @@ impl Binding_ {
 #[derive(Copy, Clone, Debug)]
 pub struct Type_(u8);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Type {
     NoType,
     Object,


### PR DESCRIPTION
This is so that users can define their own constants and match on them ([RFC 1445](https://github.com/rust-lang/rfcs/blob/master/text/1445-restrict-constants-in-patterns.md)), e.g.:

``` rust
const DT_RELACOUNT: DynTag<u64> = OsSpecific(0x6ffffff9);
```
