### PR TITLE
Use repr(C) for all Pod types

### DIFF
--- a/src/dynamic.rs
+++ b/src/dynamic.rs
@@ -2,6 +2,7 @@ use core::fmt;
 use {P32, P64};
 use zero::Pod;
 
+#[repr(C)]
 pub struct Dynamic<P> {
     tag: Tag_<P>,
     un: P,

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,6 +1,8 @@
 use symbol_table::Entry;
 use zero::Pod;
 
+#[derive(Debug)]
+#[repr(C)]
 pub struct HashTable {
     bucket_count: u32,
     chain_count: u32,

--- a/src/header.rs
+++ b/src/header.rs
@@ -118,6 +118,8 @@ impl<'a> fmt::Display for HeaderPt2<'a> {
     }
 }
 
+#[derive(Debug)]
+#[repr(C)]
 pub struct HeaderPt2_<P> {
     pub type_: Type_,
     pub machine: Machine,

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -405,6 +405,7 @@ pub const GRP_MASKOS: u64 = 0x0ff00000;
 pub const GRP_MASKPROC: u64 = 0xf0000000;
 
 #[derive(Debug)]
+#[repr(C)]
 pub struct Rela<P> {
     offset: P,
     info: P,
@@ -412,6 +413,7 @@ pub struct Rela<P> {
 }
 
 #[derive(Debug)]
+#[repr(C)]
 pub struct Rel<P> {
     offset: P,
     info: P,


### PR DESCRIPTION
Noticed because gimli tests are failing for beta/nightly in https://github.com/gimli-rs/gimli/pull/172. This is likely due to rustc field reordering in https://github.com/rust-lang/rust/pull/37429