### PR TITLE
Make Entry[32|64]::get_name actually work.

### DIFF
--- a/src/sections.rs
+++ b/src/sections.rs
@@ -89,7 +89,7 @@ impl<'a> SectionHeader<'a> {
     pub fn get_name(&self, elf_file: &ElfFile<'a>) -> Result<&'a str, &'static str> {
         self.get_type().and_then(|typ| match typ {
             ShType::Null => Err("Attempt to get name of null section"),
-            _ => elf_file.get_string(self.name()),
+            _ => elf_file.get_shstr(self.name()),
         })
     }
 


### PR DESCRIPTION
We're currently looking up strings in the `.shstrtab` section which is totally bogus.