### PR TITLE
Derive Default for ProgramHeader32/64

### DIFF
--- a/src/program.rs
+++ b/src/program.rs
@@ -55,7 +55,7 @@ pub enum ProgramHeader<'a> {
     Ph64(&'a ProgramHeader64),
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(C)]
 pub struct ProgramHeader32 {
     type_: Type_,
@@ -70,7 +70,7 @@ pub struct ProgramHeader32 {
 
 unsafe impl Pod for ProgramHeader32 {}
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(C)]
 pub struct ProgramHeader64 {
     type_: Type_,
@@ -191,7 +191,7 @@ macro_rules! ph_impl {
 ph_impl!(ProgramHeader32);
 ph_impl!(ProgramHeader64);
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct Flags(pub u32);
 
 impl Flags {
@@ -225,7 +225,7 @@ impl fmt::LowerHex for Flags {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct Type_(u32);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
This makes it possible to initialize an array of program headers, which is required for [`FixedVec`](https://docs.rs/fixedvec/0.2.3/fixedvec/).