### PR TITLE
Basic support for BPF ELF objects

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -388,6 +388,7 @@ impl Machine_ {
             0x32 => Machine::Ia64,
             0x3E => Machine::X86_64,
             0xB7 => Machine::AArch64,
+            0xF7 => Machine::BPF,
             other => Machine::Other(other),
         }
     }
@@ -412,6 +413,7 @@ pub enum Machine {
     Ia64,
     X86_64,
     AArch64,
+    BPF,
     Other(u16), // FIXME there are many, many more of these
 }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -13,7 +13,10 @@ pub fn parse_program_header<'a>(input: &'a [u8],
                                 index: u16)
                                 -> Result<ProgramHeader<'a>, &'static str> {
     let pt2 = &header.pt2;
-    assert!(index < pt2.ph_count() && pt2.ph_offset() > 0 && pt2.ph_entry_size() > 0);
+    if !(index < pt2.ph_count() && pt2.ph_offset() > 0 && pt2.ph_entry_size() > 0) {
+        return Err("There are no program headers in this file")
+    }
+
     let start = pt2.ph_offset() as usize + index as usize * pt2.ph_entry_size() as usize;
     let end = start + pt2.ph_entry_size() as usize;
 


### PR DESCRIPTION
Really minor contribution, but BPF objects don't have program headers, so this PR turns the panic into an error, and adds the BPF machine type: [ELF.h](https://github.com/llvm-mirror/llvm/blob/a80a3919ff5fabf2393ef59bc035a44e077aac28/include/llvm/BinaryFormat/ELF.h#L313).