### PR TITLE
Add PartialEq and Eq types for header types.

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -243,7 +243,7 @@ impl fmt::Debug for Data_ {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Data {
     None,
     LittleEndian,
@@ -280,7 +280,7 @@ impl fmt::Debug for Version_ {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Version {
     None,
     Current,
@@ -324,7 +324,7 @@ impl fmt::Debug for OsAbi_ {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OsAbi {
     // or None
     SystemV,
@@ -401,7 +401,7 @@ impl fmt::Debug for Machine_ {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Machine {
     None,
     Sparc,

--- a/src/program.rs
+++ b/src/program.rs
@@ -194,7 +194,7 @@ macro_rules! ph_impl {
 ph_impl!(ProgramHeader32);
 ph_impl!(ProgramHeader64);
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct Flags(pub u32);
 
 impl Flags {


### PR DESCRIPTION
This allows to do checks on ELF file for example
to decide if the given file is loadable or not.