### PR TITLE
Check length of both header parts

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -19,11 +19,19 @@ pub fn parse_header<'a>(input: &'a [u8]) -> Result<Header<'a>, &'static str> {
     let header_2 = match header_1.class() {
         Class::None | Class::Other(_) => return Err("Invalid ELF class"),
         Class::ThirtyTwo => {
+            let size_pt2 = mem::size_of::<HeaderPt2_<P32>>();
+            if input.len() < size_pt1 + size_pt2 {
+                return Err("File is shorter than ELF headers");
+            }
             let header_2: &'a HeaderPt2_<P32> =
                 read(&input[size_pt1..size_pt1 + mem::size_of::<HeaderPt2_<P32>>()]);
             HeaderPt2::Header32(header_2)
         }
         Class::SixtyFour => {
+            let size_pt2 = mem::size_of::<HeaderPt2_<P64>>();
+            if input.len() < size_pt1 + size_pt2 {
+                return Err("File is shorter than ELF headers");
+            }
             let header_2: &'a HeaderPt2_<P64> =
                 read(&input[size_pt1..size_pt1 + mem::size_of::<HeaderPt2_<P64>>()]);
             HeaderPt2::Header64(header_2)


### PR DESCRIPTION
A truncated ELF file would make the library panic. This can be illustrated by the following sequence in a Unix shell:

    $ dd if=/bin/sh of=bogus.elf bs=16 count=1
    $ cargo run bogus.elf
    thread 'main' panicked at 'index 64 out of range for slice of length 16',
      src/header.rs:28:23