### PR TITLE
Include RISC-V in machine enum

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -396,6 +396,7 @@ impl Machine_ {
             0x32 => Machine::Ia64,
             0x3E => Machine::X86_64,
             0xB7 => Machine::AArch64,
+            0xF3 => Machine::RISC_V,
             0xF7 => Machine::BPF,
             other => Machine::Other(other),
         }
@@ -421,6 +422,7 @@ pub enum Machine {
     Ia64,
     X86_64,
     AArch64,
+    RISC_V,
     BPF,
     Other(u16), // FIXME there are many, many more of these
 }


### PR DESCRIPTION
Reflect that the RISC-V processor architecture is assigned ELF machine ID 243 (0xF3) as [defined here](https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md#elf-object-file). This will allow code parsing RISC-V ELF binaries to recognize the architecture in a standard way without having to use the `Other` enum entry -- thanks!