### PR TITLE
Handle the case of empty segment (file size 0) out of range

### DIFF
--- a/src/program.rs
+++ b/src/program.rs
@@ -170,7 +170,13 @@ macro_rules! ph_impl {
 
             pub fn raw_data<'a>(&self, elf_file: &ElfFile<'a>) -> &'a [u8] {
                 assert!(self.get_type().map(|typ| typ != Type::Null).unwrap_or(false));
-                &elf_file.input[self.offset as usize..(self.offset + self.file_size) as usize]
+                if self.file_size == 0 {
+                    // When size is 0 it's not guaranteed that offset is not
+                    // outside of elf_file.input range.
+                    &[]
+                } else {
+                    &elf_file.input[self.offset as usize..(self.offset + self.file_size) as usize]
+                }
             }
         }
 


### PR DESCRIPTION
Fix the crash [mentioned](https://github.com/nrc/xmas-elf/issues/77#issuecomment-1299351040) by @sleffler in #77, "when the last LOAD segment has a file_size=0".

Note that this fix is for `ProgramHeader.raw_data`, and #77 (original message) is about `SectionHeader.raw_data`, so it does not fix #77. 