### PR TITLE
Fix the lifetime of `progam_iter` items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ impl<'a> ElfFile<'a> {
         program::parse_program_header(self.input, self.header, index)
     }
 
-    pub fn program_iter(&self) -> impl Iterator<Item = ProgramHeader<'_>> {
+    pub fn program_iter(&self) -> impl Iterator<Item = ProgramHeader<'a>> + '_ {
         ProgramIter {
             file: self,
             next_index: 0,


### PR DESCRIPTION
The `ProgramHeader` objects produced by `ElfFile::program_iter` should have the same lifetime as the `ElfFile`, i.e. the lifetime of the input data. Prior to this PR, they instead had the shorter of a) the `ElfFile` lifetime and b) the `&self` reference lifetime, making code dealing with these `ProgramHeader`s awkward to write.

This PR fixes the lifetime issue by making the lifetime annotations the same as for `ElfFile::section_iter`.

It seems like the issue was originally introduced in https://github.com/nrc/xmas-elf/pull/69. That PR also annotates `section_iter` correctly, so I'm unsure why a different approach was chosen for `program_iter`.